### PR TITLE
Fix Compile Error When Using G++.

### DIFF
--- a/evmwrap/host_bridge/tx_ctrl.cpp
+++ b/evmwrap/host_bridge/tx_ctrl.cpp
@@ -130,7 +130,8 @@ const bytecode_entry& cached_state::get_bytecode_entry(const evmc_address& addr)
 	if(iter != bytecodes.end()) {
 		return iter->second;
 	}
-	bytecode_entry e = {.dirty=false};
+	bytecode_entry e;
+	e.dirty = false;
 	e.bytecode = world->get_bytecode(addr, &e.codehash);
 	if(e.bytecode.size() == 0) {
 		e.codehash = HASH_FOR_ZEROCODE;

--- a/evmwrap/host_bridge/tx_ctrl.h
+++ b/evmwrap/host_bridge/tx_ctrl.h
@@ -144,7 +144,8 @@ struct world_state_reader {
 	}
 	account_info get_account(const evmc_address& addr) {
 		evmc_bytes32 balance;
-		account_info info = {.selfdestructed=false};
+		account_info info;
+		info.selfdestructed = false;
 		get_account_info_fn(handler, (evmc_address*)(&addr)/*drop const*/, &balance, &info.nonce, &info.sequence);
 		info.balance = u256be_to_u256(balance);
 		return info;


### PR DESCRIPTION
G++ does not support non-trivial designated initializers .